### PR TITLE
Fix author fields not appearing on sidebar

### DIFF
--- a/src/addAuthorFields.ts
+++ b/src/addAuthorFields.ts
@@ -157,7 +157,7 @@ const createField = ({
           ? undefined
           : (props: any) => getDisplayOnlyField({ ...props, pluginConfig }),
       },
-      condition: () => typeof window !== 'undefined' && window.location.pathname.includes('create-first-user'),
+      condition: () => typeof window !== 'undefined' && !window.location.pathname.includes('create-first-user'),
     },
     access: {
       read: pluginConfig.fieldAccess,


### PR DESCRIPTION
I believe the commit 8b93522 may have a mistake in which, 

```js
condition: () => window?.location.pathname !== '/admin/create-first-user',
```

becomes:

```js
condition: () => typeof window !== 'undefined' && window.location.pathname.includes('create-first-user'),
```

when it should be:

```js
condition: () => typeof window !== 'undefined' && !window.location.pathname.includes('create-first-user'),
```